### PR TITLE
Add context type constant

### DIFF
--- a/lti_tool/constants.py
+++ b/lti_tool/constants.py
@@ -33,7 +33,7 @@ class ContextType(str, Enum):
 
     @property
     def short_name(self) -> str:
-        """"Return the short name of this context."""
+        """Return the short name of this context."""
         return self.value[len(CONTEXT_TYPE_PATTERN.format("")) :]
 
     @property

--- a/lti_tool/constants.py
+++ b/lti_tool/constants.py
@@ -4,6 +4,8 @@ SESSION_KEY = "_lti_tool_launch_id"
 
 CONTEXT_ROLE_PATTERN = "http://purl.imsglobal.org/vocab/lis/v2/membership#{}"
 
+CONTEXT_TYPE_PATTERN = "http://purl.imsglobal.org/vocab/lis/v2/course#{}"
+
 
 class ContextRole(str, Enum):
     ADMINISTRATOR = CONTEXT_ROLE_PATTERN.format("Administrator")
@@ -19,5 +21,22 @@ class ContextRole(str, Enum):
 
     @property
     def full_name(self) -> str:
-        """Return the full name of this roles."""
+        """Return the full name of this role."""
+        return self.value
+
+
+class ContextType(str, Enum):
+    COURSE_TEMPLATE = CONTEXT_TYPE_PATTERN.format("CourseTemplate")
+    COURSE_OFFERING = CONTEXT_TYPE_PATTERN.format("CourseOffering")
+    COURSE_SECTION = CONTEXT_TYPE_PATTERN.format("CourseSection")
+    GROUP = CONTEXT_TYPE_PATTERN.format("Group")
+
+    @property
+    def short_name(self) -> str:
+        """"Return the short name of this context."""
+        return self.value[len(CONTEXT_TYPE_PATTERN.format("")) :]
+
+    @property
+    def full_name(self) -> str:
+        """Return the full name of this context."""
         return self.value

--- a/lti_tool/utils.py
+++ b/lti_tool/utils.py
@@ -8,7 +8,7 @@ from pylti1p3.contrib.django.message_launch import DjangoMessageLaunch
 from pylti1p3.deployment import Deployment
 from pylti1p3.tool_config.abstract import ToolConfAbstract
 
-from .constants import ContextRole
+from .constants import ContextRole, ContextType
 from .models import (
     LtiContext,
     LtiDeployment,
@@ -154,19 +154,16 @@ def sync_context_from_launch(lti_launch: LtiLaunch) -> LtiContext:
             "title": context_claim.get("title", ""),
             "label": context_claim.get("label", ""),
             "is_course_template": (
-                "http://purl.imsglobal.org/vocab/lis/v2/course#CourseTemplate"
-                in context_types
+                ContextType.COURSE_TEMPLATE in context_types
             ),
             "is_course_offering": (
-                "http://purl.imsglobal.org/vocab/lis/v2/course#CourseOffering"
-                in context_types
+                ContextType.COURSE_OFFERING in context_types
             ),
             "is_course_section": (
-                "http://purl.imsglobal.org/vocab/lis/v2/course#CourseSection"
-                in context_types
+                ContextType.COURSE_SECTION in context_types
             ),
             "is_group": (
-                "http://purl.imsglobal.org/vocab/lis/v2/course#Group" in context_types
+                ContextType.GROUP in context_types
             ),
         }
         if nrps_endpoint:

--- a/lti_tool/utils.py
+++ b/lti_tool/utils.py
@@ -153,18 +153,10 @@ def sync_context_from_launch(lti_launch: LtiLaunch) -> LtiContext:
         defaults = {
             "title": context_claim.get("title", ""),
             "label": context_claim.get("label", ""),
-            "is_course_template": (
-                ContextType.COURSE_TEMPLATE in context_types
-            ),
-            "is_course_offering": (
-                ContextType.COURSE_OFFERING in context_types
-            ),
-            "is_course_section": (
-                ContextType.COURSE_SECTION in context_types
-            ),
-            "is_group": (
-                ContextType.GROUP in context_types
-            ),
+            "is_course_template": (ContextType.COURSE_TEMPLATE in context_types),
+            "is_course_offering": (ContextType.COURSE_OFFERING in context_types),
+            "is_course_section": (ContextType.COURSE_SECTION in context_types),
+            "is_group": (ContextType.GROUP in context_types),
         }
         if nrps_endpoint:
             defaults["memberships_url"] = nrps_endpoint


### PR DESCRIPTION
This PR adds a ContextType constant based on the [context type vocabulary](https://www.imsglobal.org/spec/lti/v1p3/#context-type-vocabulary) defined in the LTI 1.3 spec. 

This PR also updates `utils.sync_context_from_launch()` to use these constants. 

Closes #28. 