### PR TITLE
Add InstitutionRole constant

### DIFF
--- a/lti_tool/constants.py
+++ b/lti_tool/constants.py
@@ -8,7 +8,9 @@ SYSTEM_ROLE_PATTERN = "http://purl.imsglobal.org/vocab/lis/v2/system/person#{}"
 
 CONTEXT_TYPE_PATTERN = "http://purl.imsglobal.org/vocab/lis/v2/course#{}"
 
-INSTITUTION_TYPE_PATTERN = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#{}"
+INSTITUTION_TYPE_PATTERN = (
+    "http://purl.imsglobal.org/vocab/lis/v2/institution/person#{}"
+)
 
 
 class ContextRole(str, Enum):

--- a/lti_tool/constants.py
+++ b/lti_tool/constants.py
@@ -8,6 +8,8 @@ SYSTEM_ROLE_PATTERN = "http://purl.imsglobal.org/vocab/lis/v2/system/person#{}"
 
 CONTEXT_TYPE_PATTERN = "http://purl.imsglobal.org/vocab/lis/v2/course#{}"
 
+INSTITUTION_TYPE_PATTERN = "http://purl.imsglobal.org/vocab/lis/v2/institution/person#{}"
+
 
 class ContextRole(str, Enum):
     ADMINISTRATOR = CONTEXT_ROLE_PATTERN.format("Administrator")
@@ -57,6 +59,33 @@ class SystemRole(str, Enum):
     def short_name(self) -> str:
         """Return the short name of this role."""
         return self.value[len(SYSTEM_ROLE_PATTERN.format("")) :]
+
+    @property
+    def full_name(self) -> str:
+        """Return the full name of this roles."""
+        return self.value
+
+
+class InstitutionRole(str, Enum):
+    ADMINISTRATOR = INSTITUTION_TYPE_PATTERN.format("Administrator")
+    FACULTY = INSTITUTION_TYPE_PATTERN.format("Faculty")
+    GUEST = INSTITUTION_TYPE_PATTERN.format("Guest")
+    NONE = INSTITUTION_TYPE_PATTERN.format("None")
+    OTHER = INSTITUTION_TYPE_PATTERN.format("Other")
+    STAFF = INSTITUTION_TYPE_PATTERN.format("Staff")
+    STUDENT = INSTITUTION_TYPE_PATTERN.format("Student")
+    ALUMNI = INSTITUTION_TYPE_PATTERN.format("Alumni")
+    INSTRUCTOR = INSTITUTION_TYPE_PATTERN.format("Instructor")
+    LEARNER = INSTITUTION_TYPE_PATTERN.format("Learner")
+    MEMBER = INSTITUTION_TYPE_PATTERN.format("Member")
+    MENTOR = INSTITUTION_TYPE_PATTERN.format("Mentor")
+    OBSERVER = INSTITUTION_TYPE_PATTERN.format("Observer")
+    PROSPECTIVE_STUDENT = INSTITUTION_TYPE_PATTERN.format("ProspectiveStudent")
+
+    @property
+    def short_name(self) -> str:
+        """Return the short name of this role."""
+        return self.value[len(INSTITUTION_TYPE_PATTERN.format("")) :]
 
     @property
     def full_name(self) -> str:


### PR DESCRIPTION
This PR adds an InstitutionRole constant based on the [vocabulary defined in the LTI 1.3 spec](https://www.imsglobal.org/spec/lti/v1p3/#lis-vocabulary-for-institution-roles).

Closes #30.
