### PR TITLE
Deployment handling interface

### DIFF
--- a/docs/launch_handling.rst
+++ b/docs/launch_handling.rst
@@ -36,6 +36,38 @@ Each application will handle a launch differently, but common tasks include:
 - Starting an asynchronous task to fetch course members from the platform
 - Redirecting to an appropriate page based on launch data
 
+Handling Deployments
+--------------------
+
+By default, :class:`~lti_tool.views.LtiLaunchBaseView` will return an error if the
+:class:`~lti_tool.models.LtiDeployment` associated with the launch is inactive. In this
+case, a tool administrator will need to manually activate each new deployment using the
+Django admin or a custom built interface.
+
+To implement custom behavior for handling inactive deployments, tools may
+override the :meth:`~lti_tool.views.LtiLaunchBaseView.handle_inactive_deployment`
+method and return a custom response.
+
+.. code-block:: python
+
+    class ApplicationLaunchView(LtiLaunchBaseView):
+
+        def handle_inactive_deployment(self, request, lti_launch):
+            return HttpResponseRedirect(custom_deployment_activation_url)
+
+Tools wishing to automatically activate new deployments (either universally, or based
+on specific criteria) may do so by implementing the
+:meth:`~lti_tool.views.LtiLaunchBaseView.launch_setup` method.
+
+.. code-block:: python
+
+    class ApplicationLaunchView(LtiLaunchBaseView):
+
+        def launch_setup(self, request, lti_launch):
+            if not lti_launch.deployment.is_active:
+                lti_launch.deployment.is_active = True
+                lti_launch.deployment.save()
+
 Other Launch Messages
 ---------------------
 

--- a/lti_tool/views.py
+++ b/lti_tool/views.py
@@ -67,6 +67,7 @@ class LtiLaunchBaseView(View):
         request.session.clear()
         lti_launch = get_launch_from_request(request)
         sync_data_from_launch(lti_launch)
+        self.launch_setup(request, lti_launch)
         if not lti_launch.deployment.is_active:
             return self.handle_inactive_deployment(request, lti_launch)
         request.session[SESSION_KEY] = lti_launch.get_launch_id()
@@ -79,6 +80,9 @@ class LtiLaunchBaseView(View):
             return self.handle_submission_review_launch(request, lti_launch)
         if request.lti_launch.is_data_privacy_launch:
             return self.handle_data_privacy_launch(request, lti_launch)
+
+    def launch_setup(self, request: HttpRequest, lti_launch: LtiLaunch) -> None:
+        pass
 
     def handle_inactive_deployment(
         self, request: HttpRequest, lti_launch: LtiLaunch

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -283,3 +283,50 @@ class TestSyncPlatformInstanceFromLaunch:
         assert updated_platform_instance.product_family_code == "example"
         assert updated_platform_instance.version == "1.0"
         assert updated_platform_instance.deployments.first() == deployment
+
+
+@pytest.mark.django_db
+class TestDjangoToolConfig:
+    """Tests for utils.DjangoToolConfig."""
+
+    @pytest.mark.parametrize("is_known_deployment", (True, False))
+    def test_find_deployment(self, is_known_deployment):
+        models.Key.objects.generate()
+        registration = factories.LtiRegistrationFactory()
+        deployment_id = "a-deployment"
+        if is_known_deployment:
+            factories.LtiDeploymentFactory(
+                registration=registration, deployment_id=deployment_id, is_active=True
+            )
+
+        tool_config = utils.DjangoToolConfig(registration_uuid=registration.uuid)
+        tool_config.find_registration_by_issuer(registration.issuer)
+        deployment = tool_config.find_deployment(registration.issuer, deployment_id)
+
+        assert deployment.get_deployment_id() == deployment_id
+        assert tool_config.deployment.deployment_id == deployment_id
+        assert tool_config.deployment.is_active == is_known_deployment
+        assert models.LtiDeployment.objects.count() == 1
+
+    @pytest.mark.parametrize("is_known_deployment", (True, False))
+    def test_find_deployment_by_params(self, is_known_deployment):
+        models.Key.objects.generate()
+        registration = factories.LtiRegistrationFactory()
+        deployment_id = "a-deployment"
+        if is_known_deployment:
+            factories.LtiDeploymentFactory(
+                registration=registration, deployment_id=deployment_id, is_active=True
+            )
+
+        tool_config = utils.DjangoToolConfig()
+        tool_config.find_registration_by_params(
+            registration.issuer, registration.client_id
+        )
+        deployment = tool_config.find_deployment_by_params(
+            registration.issuer, deployment_id, registration.client_id
+        )
+
+        assert deployment.get_deployment_id() == deployment_id
+        assert tool_config.deployment.deployment_id == deployment_id
+        assert tool_config.deployment.is_active == is_known_deployment
+        assert models.LtiDeployment.objects.count() == 1


### PR DESCRIPTION
Looking for feedback on this approach to addressing #26. A few items to call out...

1. When a launch occurs with a deployment ID that has not been seen previously by the tool, we are now creating a new, inactive `LtiDeployment`.
2. To account for the previous change we are handling launches with inactive deployments using the new `handle_inactive_deployment` method of `LtiLaunchBaseView`. By default a slightly helpful message is returned (better than the previous behavior of raising an exception, I think). This also allows for more sophisticated behaviors, like redirecting to a page where the user could submit a deployment activation request or associate it with a paid license.
3. A tool can modify a deployments status prior to handling a launch by implementing the new `launch_setup` method. Suggestions for a more appropriate name are welcome. This allows workflows like automatically activating all deployments for a specific registration (or for _every_ registration).