### PR TITLE
support alternative cookie messages in UI (iss. #107)

### DIFF
--- a/docs/oidc_initiation.rst
+++ b/docs/oidc_initiation.rst
@@ -16,8 +16,30 @@ to return an authentication request to the platform
 
 .. code-block:: python
 
-    ...
+    # ...
+    from lti_tool.views import OIDCLoginInitView
 
+    urlpatterns = [
+        path("init/<uuid:registration_uuid/", OIDCLoginInitView.as_view(), name="init"),
+        # ...
+    ]
+
+The ``registration_uuid`` parameter is a reference to the
+:attr:`LtiRegistration.uuid <lti_tool.models.LtiRegistration.uuid>` property, and is
+used to identify the platform registration associated with the initiation request.
+
+
+Customizing language for blocked cookies
+----------------------------------------
+
+When the user's browser prevents embedded content from setting cookies within an
+``iframe``, the module displays a message about it and a link to open the
+content in a new tab or window.  The language of the message and link may be
+customized using optional message arguments to ``OIDCLoginInitView.as_view()``…
+
+.. code-block:: python
+
+    # ...
     from lti_tool.views import OIDCLoginInitView
 
     urlpatterns = [
@@ -31,10 +53,6 @@ to return an authentication request to the platform
         ), name="init"),
         # ...
     ]
-
-The ``registration_uuid`` parameter is a reference to the
-:attr:`LtiRegistration.uuid <lti_tool.models.LtiRegistration.uuid>` property, and is
-used to identify the platform registration associated with the initiation request.
 
 The ``main_msg``, ``click_msg``, and ``loading_msg`` **optional** arguments are
 passed to ``DjangoOIDCLogin.enable_check_cookies()`` to generate messages shown

--- a/docs/oidc_initiation.rst
+++ b/docs/oidc_initiation.rst
@@ -21,13 +21,28 @@ to return an authentication request to the platform
     from lti_tool.views import OIDCLoginInitView
 
     urlpatterns = [
-        path("init/<uuid:registration_uuid/", OIDCLoginInitView.as_view(), name="init"),
-        ...
+        path("init/<uuid:registration_uuid/", OIDCLoginInitView.as_view(
+            main_msg=(
+                "Your browser prevents embedded content from using cookies.  To work "
+                "around this, the content must be opened in a new tab or window.  "
+            ),
+            click_msg="Open a new tab or window now.",
+            loading_msg="Loading..."
+        ), name="init"),
+        # ...
     ]
 
 The ``registration_uuid`` parameter is a reference to the
 :attr:`LtiRegistration.uuid <lti_tool.models.LtiRegistration.uuid>` property, and is
 used to identify the platform registration associated with the initiation request.
+
+The ``main_msg``, ``click_msg``, and ``loading_msg`` **optional** arguments are
+passed to ``DjangoOIDCLogin.enable_check_cookies()`` to generate messages shown
+in the UI.  The values shown here are the default values used by
+``OIDCLoginInitView``.  If cookies are not allowed by the browser, the value of
+``main_msg`` will be shown.  That will be followed by a link with label
+containing the value of ``click_msg``, which opens the content in a new tab or
+window.
 
 Customizing the authentication request
 --------------------------------------

--- a/lti_tool/views.py
+++ b/lti_tool/views.py
@@ -31,6 +31,10 @@ def jwks(request):
 @method_decorator(csrf_exempt, name="dispatch")
 class OIDCLoginInitView(View):
     """Handles OIDC 3rd-party login initiation for an LTI launch."""
+
+    """
+    Message strings used by `DjangoOIDCLogin.enable_check_cookies()`.
+    """
     main_msg: Optional[str] = None
     click_msg: Optional[str] = None
     loading_msg: Optional[str] = None

--- a/lti_tool/views.py
+++ b/lti_tool/views.py
@@ -30,15 +30,12 @@ def jwks(request):
 class OIDCLoginInitView(View):
     """Handles OIDC 3rd-party login initiation for an LTI launch."""
 
-    """
-    Message strings used by `DjangoOIDCLogin.enable_check_cookies()`.
-    """
-    main_msg: str = (
+    main_msg = (
         "Your browser prevents embedded content from using cookies.  To work "
         "around this, the content must be opened in a new tab or window.  "
     )
-    click_msg: str = "Open a new tab or window now."
-    loading_msg: str = "Loading..."
+    click_msg = "Open a new tab or window now."
+    loading_msg = "Loading..."
 
     def get(self, request, *args, **kwargs):
         registration_uuid = kwargs.get("registration_uuid")

--- a/lti_tool/views.py
+++ b/lti_tool/views.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from django.http import (
     HttpRequest,
     HttpResponse,
@@ -35,9 +33,12 @@ class OIDCLoginInitView(View):
     """
     Message strings used by `DjangoOIDCLogin.enable_check_cookies()`.
     """
-    main_msg: Optional[str] = None
-    click_msg: Optional[str] = None
-    loading_msg: Optional[str] = None
+    main_msg: str = (
+        "Your browser prevents embedded content from using cookies.  To work "
+        "around this, the content must be opened in a new tab or window.  "
+    )
+    click_msg: str = "Open a new tab or window now."
+    loading_msg: str = "Loading..."
 
     def get(self, request, *args, **kwargs):
         registration_uuid = kwargs.get("registration_uuid")

--- a/lti_tool/views.py
+++ b/lti_tool/views.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from django.http import (
     HttpRequest,
     HttpResponse,
@@ -29,6 +31,9 @@ def jwks(request):
 @method_decorator(csrf_exempt, name="dispatch")
 class OIDCLoginInitView(View):
     """Handles OIDC 3rd-party login initiation for an LTI launch."""
+    main_msg: Optional[str] = None
+    click_msg: Optional[str] = None
+    loading_msg: Optional[str] = None
 
     def get(self, request, *args, **kwargs):
         registration_uuid = kwargs.get("registration_uuid")
@@ -52,7 +57,9 @@ class OIDCLoginInitView(View):
         if target_link_uri is None:
             return HttpResponseBadRequest("Missing target_link_uri parameter.")
         redirect_url = self.get_redirect_url(target_link_uri)
-        return oidc_login.enable_check_cookies().redirect(redirect_url)
+        return oidc_login.enable_check_cookies(
+            self.main_msg, self.click_msg, self.loading_msg
+        ).redirect(redirect_url)
 
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,4 +50,4 @@ extend-ignore =
   D105,  # Missing docstring in magic method
   D106,  # Missing docstring in public nested class
   D107,  # Missing docstring in __init__
-exclude = build/*, env/*, venv/*, .nox, lti_tool/migrations/*
+exclude = build/*, env/*, venv/*, .venv/*, .nox, lti_tool/migrations/*


### PR DESCRIPTION
Resolves #107.

I noticed that `OIDCLoginInitView`'s inherited method `View.as_view()`, being called from an @tl-its-umich-edu LTI project, accepted a list of various keyword arguments.  I experimented with that and learned that by defining the arguments as attributes of `OIDCLoginInitView`, they would be accepted and could later be accessed as instance properties where `DjangoOIDCLogin.enable_check_cookies()` is called.

This could be used as…

```python
    path("init/<uuid:registration_uuid/", OIDCLoginInitView.as_view(
        main_msg=(
            "Your browser prevents embedded content from using cookies.  To work "
            "around this, the content must be opened in a new tab or window.  "
        ),
        click_msg="Open a new tab or window now.",
        loading_msg="Loading..."
    ), name="init")
```