### PR TITLE
Introduce LtiConfigView

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ To allow LTI platforms to retrieve a JWKS and initiate a launch, add paths for
 ```python
 ...
 
-from lti_tool.views import jwks, OIDCLoginInitView
+from lti_tool.views import jwks, OIDCLoginInitView, LtiConfigView
 
 urlpatterns = [
     path(".well-known/jwks.json", jwks, name="jwks"),
     path("init/<uuid:registration_uuid>/", OIDCLoginInitView.as_view(), name="init"),
+    path("<uuid:registration_uuid>/config.json", LtiConfigView.as_view()),
 ]
 
 ```


### PR DESCRIPTION
So this is just an idea - feel free to shut this down if this doesn't really fit into the vision of the django-lti library.

Basically, I had an idea to add a new `config.json` route which would depend on the registration uuid. At least with Canvas LMS, this endpoint can be used to autoconfigure the LTI application, making integration much simpler at the admin level. This way the application author can specify exactly where the LTI App intends to be placed within the LMS, like the XML config schema we were using in LTI 1.1. This is much more reliable than manually configuring these fields each time the LTI application is installed.

I'm assuming this will require some discussion and refinements, so I'm opening this up as a draft PR.

This is something the application author can create themselves, here is an example of that:
* https://github.com/ccnmtl/mediathread/blob/master/lti_auth/views.py#L135

And I've generalized that view which is included here.

I think that anything django-lti can pre-configure itself like this would be beneficial to application developers. Personally I've found LTI 1.3 pretty complicated to work with as it is, so I'd like for a library like this to simplify whatever it can.