### PR TITLE
Display LtiRegistration creation time in admin

### DIFF
--- a/lti_tool/admin.py
+++ b/lti_tool/admin.py
@@ -10,6 +10,7 @@ class LtiDeploymentInline(admin.TabularInline):
 
 @admin.register(models.LtiRegistration)
 class LtiRegistrationAdmin(admin.ModelAdmin):
+    list_display = ["name", "datetime_created", "is_active"]
     fieldsets = [
         (
             None,


### PR DESCRIPTION
It can be useful to display the creation time for these LtiRegistration objects here on this list view. I've also added the is_active flag.