### PR TITLE
Add issuer and client_id to the LtiRegistration list view

### DIFF
--- a/lti_tool/admin.py
+++ b/lti_tool/admin.py
@@ -10,7 +10,7 @@ class LtiDeploymentInline(admin.TabularInline):
 
 @admin.register(models.LtiRegistration)
 class LtiRegistrationAdmin(admin.ModelAdmin):
-    list_display = ["name", "datetime_created", "is_active"]
+    list_display = ["name", "issuer", "client_id", "datetime_created", "is_active"]
     fieldsets = [
         (
             None,


### PR DESCRIPTION
Adds `issuer` and `client_id` to the LtiRegistration list view in the Django admin interface. 

Closes #144.